### PR TITLE
fix: remove extraneous files when packaging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,9 +26,7 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn install --frozen-lockfile --check-files
-      - name: Build project
-        run: yarn build:production
-      - name: Publish version
+      - name: Publish to marketplace
         run: yarn deploy
         env:
           VSCE_PAT: ${{ secrets.VSCE_TOKEN }}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,6 +4,8 @@
 out/test/**
 src/**
 
+node_modules/**
+
 .editorconfig
 .gitignore
 .eslintrc.js

--- a/package.json
+++ b/package.json
@@ -47,12 +47,10 @@
 		"lint": "eslint src --ext ts",
 		"deploy": "vsce publish --yarn"
 	},
-	"dependencies": {
-		"@expo/xdl": "^57.9.1"
-	},
 	"devDependencies": {
 		"@babel/core": "^7.9.6",
 		"@expo/babel-preset-cli": "^0.2.11",
+		"@expo/xdl": "^57.9.1",
 		"@types/glob": "^7.1.1",
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^13.11.0",


### PR DESCRIPTION
### Linked issue
Removes additional dependencies and code when installing the plugin, should speed up installing the plugin.

### Additional context
- `$ yarn build` creates a non-minified build using `node_modules`, ideal for developing
- `$ yarn build:production` creates a minified build without the need of `node_modules`, ideal for production
