### PR TITLE
chore: add missing test when failing to enhance schema

### DIFF
--- a/src/manifest/__tests__/__mocks__/json-schema-traverse.ts
+++ b/src/manifest/__tests__/__mocks__/json-schema-traverse.ts
@@ -1,0 +1,4 @@
+import traverse from 'json-schema-traverse';
+
+// note: it's similar as `jest.spyOn`, but as workaround for default exports
+export default jest.fn(traverse);


### PR DESCRIPTION
### Linked issue
Adds the missing test to fall back on the simple (non-enhanced) schema.